### PR TITLE
Rewrite for Sonatype acquisition of OSSIndex.

### DIFF
--- a/VorSecurity/InedoExtension/InedoExtension.csproj
+++ b/VorSecurity/InedoExtension/InedoExtension.csproj
@@ -62,6 +62,10 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VulnerabilitySources\VorSecurityVulnerabilitySource.cs" />
+    <Compile Include="VulnerabilitySources\PackageId.cs" />
+    <Compile Include="VulnerabilitySources\PackageVulnerabilities.cs" />
+    <Compile Include="VulnerabilitySources\Vulnerability.cs" />
+    <Compile Include="VulnerabilitySources\VulnerabilityInfoImpl.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/VorSecurity/InedoExtension/VulnerabilitySources/PackageId.cs
+++ b/VorSecurity/InedoExtension/VulnerabilitySources/PackageId.cs
@@ -1,0 +1,48 @@
+﻿using Newtonsoft.Json;
+using Inedo.Extensibility.VulnerabilitySources;
+using Inedo.Feeds;
+
+namespace Inedo.ProGet.Extensions.VorSecurity.VulnerabilitySources
+{
+    public sealed partial class VorSecurityVulnerabilitySource
+    {
+        [JsonObject]
+        private sealed class PackageId
+        {
+            [JsonIgnore]
+            internal IVulnerabilityPackage Package { get; }
+            [JsonProperty("pm")]
+            public string PackageManager { get; }
+            [JsonProperty("name")]
+            public string Name { get; }
+
+            private PackageId(IVulnerabilityPackage package, string packageManager, string name)
+            {
+                this.Package = package;
+                this.PackageManager = packageManager;
+                this.Name = name;
+            }
+
+            internal static PackageId TryCreate(IVulnerabilityPackage package)
+            {
+                switch (package.FeedType)
+                {
+                    case FeedType.Bower:
+                        return new PackageId(package, "bower", package.Name);
+                    case FeedType.Chocolatey:
+                        return new PackageId(package, "chocolatey", package.Name);
+                    case FeedType.Deployment:
+                    case FeedType.NuGet:
+                    case FeedType.PowerShell:
+                        return new PackageId(package, "nuget", package.Name);
+                    case FeedType.Maven:
+                        return null; // TODO: implement this when the v2 API supports Maven
+                    case FeedType.Npm:
+                        return new PackageId(package, "npm", package.Name);
+                    default:
+                        return null;
+                }
+            }
+        }
+    }
+}

--- a/VorSecurity/InedoExtension/VulnerabilitySources/PackageVulnerabilities.cs
+++ b/VorSecurity/InedoExtension/VulnerabilitySources/PackageVulnerabilities.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Inedo.ProGet.Extensions.VorSecurity.VulnerabilitySources
+{
+    public sealed partial class VorSecurityVulnerabilitySource
+    {
+        [JsonObject]
+        private sealed partial class PackageVulnerabilities
+        {
+            [JsonProperty("id")]
+            public long ID { get; set; }
+            [JsonProperty("pm")]
+            public string PackageManager { get; set; }
+            [JsonProperty("name")]
+            public string Name { get; set; }
+            [JsonProperty("vulnerability-total")]
+            public int TotalVulnerabilities { get; set; }
+            [JsonProperty("vulnerability-matches")]
+            public int MatchedVulnerabilities { get; set; }
+            [JsonProperty("vulnerabilities")]
+            public List<Vulnerability> Vulnerabilities { get; } = new List<Vulnerability>();
+
+            private bool IsMatch(PackageId id)
+            {
+                return string.Equals(this.PackageManager, id.PackageManager, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(this.Name, id.Name, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+}

--- a/VorSecurity/InedoExtension/VulnerabilitySources/VorSecurityVulnerabilitySource.cs
+++ b/VorSecurity/InedoExtension/VulnerabilitySources/VorSecurityVulnerabilitySource.cs
@@ -1,26 +1,20 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Security;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Inedo.Diagnostics;
 using Inedo.Documentation;
 using Inedo.Extensibility.VulnerabilitySources;
-using Inedo.Feeds;
-using Inedo.IO;
 using Inedo.Serialization;
-using Newtonsoft.Json;
 
 namespace Inedo.ProGet.Extensions.VorSecurity.VulnerabilitySources
 {
     [DisplayName("Vör Security")]
     [Description("Automatically imports vulnerability information from Vör Security.")]
-    public sealed class VorSecurityVulnerabilitySource : VulnerabilitySource
+    public sealed partial class VorSecurityVulnerabilitySource : VulnerabilitySource
     {
         [Required]
         [Persistent]
@@ -36,314 +30,17 @@ namespace Inedo.ProGet.Extensions.VorSecurity.VulnerabilitySources
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            var status = await this.RequestReportAsync(context).ConfigureAwait(false);
-            this.LogStatus(status);
+            var packages = context.Packages.Select(PackageId.TryCreate).Where(p => p != null).ToArray();
 
-            while (status.status == ReportStatus.Pending || status.status == ReportStatus.Running)
-            {
-                await Task.Delay(5000).ConfigureAwait(false);
-
-                var newStatus = await this.GetReportStatusAsync(status.id).ConfigureAwait(false);
-                this.LogStatus(newStatus, status);
-                status = newStatus;
-            }
-
-            if (status.status == ReportStatus.Finished)
-            {
-                this.LogInformation("Requesting report...");
-                var packages = await this.GetReportAsync(status.id).ConfigureAwait(false);
-                this.LogInformation($"Report receieved (packages: {packages.Length}).");
-                return EnumerateVulnerabilities(packages);
-            }
-
-            if (status.status == ReportStatus.Error)
-            {
-                this.LogError("Report generation failed.");
-                return null;
-            }
-
-            this.LogError("Unexpected status received.");
-            return null;
-        }
-
-        private static IEnumerable<VulnerabilityInfo> EnumerateVulnerabilities(VorPackage[] packages)
-        {
-            foreach (var p in packages)
-            {
-                if (p.vulnerabilities != null)
-                {
-                    foreach (var v in p.vulnerabilities)
-                        yield return new VorVulnerabilityInfo(p, v);
-                }
-            }
-        }
-        private async Task<VorPackage[]> GetReportAsync(string id)
-        {
-            var client = new HttpClient();
-            client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", this.UserName + ":" + AH.Unprotect(this.ApiKey));
-
-            using (var response = await client.GetAsync("https://vorsecurity.com/92614235v2.0/report/" + id).ConfigureAwait(false))
+            using (var client = new HttpClient())
+            using (var content = new StringContent(JsonConvert.SerializeObject(packages), InedoLib.UTF8Encoding, "application/json"))
+            using (var response = await client.PostAsync("https://ossindex.net/v2.0/package", content))
             {
                 response.EnsureSuccessStatusCode();
 
-                if (!string.Equals(response.Content.Headers.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase))
-                    throw new InvalidDataException($"Response Content-Type was {response.Content.Headers.ContentType?.MediaType} (expected application/json).");
-
-                using (var jsonReader = new JsonTextReader(new StreamReader(await response.Content.ReadAsStreamAsync().ConfigureAwait(false), InedoLib.UTF8Encoding)))
-                {
-                    return new JsonSerializer().Deserialize<VorPackage[]>(jsonReader);
-                }
+                return JsonConvert.DeserializeObject<IEnumerable<PackageVulnerabilities>>(await response.Content.ReadAsStringAsync())
+                    .SelectMany(p => p.Vulnerabilities.Select(v => v.GetInfo(p, packages)));
             }
-        }
-        private void LogStatus(ReportStatus status, ReportStatus oldStatus = null)
-        {
-            // do not log if status has not changed
-            if (status.status == oldStatus?.status && status.statusText == oldStatus?.statusText)
-                return;
-
-            switch (status.status)
-            {
-                case ReportStatus.Finished:
-                    this.LogInformation("Report status is finished: " + status.statusText);
-                    break;
-
-                case ReportStatus.Error:
-                    this.LogError("Report status is error: " + status.statusText);
-                    break;
-
-                default:
-                case ReportStatus.Pending:
-                case ReportStatus.Running:
-                    this.LogDebug($"Report status is {status.status}: {status.statusText}");
-                    break;
-            }
-        }
-        private async Task<ReportStatus> GetReportStatusAsync(string id)
-        {
-            var client = new HttpClient();
-            client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", this.UserName + ":" + AH.Unprotect(this.ApiKey));
-
-            using (var response = await client.GetAsync("https://vorsecurity.com/92614235v2.0/status/" + id).ConfigureAwait(false))
-            {
-                return await ProcessReportStatusAsync(response).ConfigureAwait(false);
-            }
-        }
-        private async Task<ReportStatus> RequestReportAsync(IVulnerabilitySourceContext context)
-        {
-            var client = new HttpClient();
-            client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", this.UserName + ":" + AH.Unprotect(this.ApiKey));
-
-            using (var streamContent = new StreamContent(GetPackageRequestStream(context)))
-            {
-                streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-
-                using (var response = await client.PostAsync("https://vorsecurity.com/92614235v2.0/package", streamContent).ConfigureAwait(false))
-                {
-                    return await ProcessReportStatusAsync(response).ConfigureAwait(false);
-                }
-            }
-        }
-        private static async Task<ReportStatus> ProcessReportStatusAsync(HttpResponseMessage response)
-        {
-            response.EnsureSuccessStatusCode();
-
-            if (!string.Equals(response.Content.Headers.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase))
-                throw new InvalidDataException($"Response Content-Type was {response.Content.Headers.ContentType?.MediaType} (expected application/json).");
-
-            using (var jsonReader = new JsonTextReader(new StreamReader(await response.Content.ReadAsStreamAsync().ConfigureAwait(false), InedoLib.UTF8Encoding)))
-            {
-                return new JsonSerializer().Deserialize<ReportStatus>(jsonReader);
-            }
-        }
-        private static Stream GetPackageRequestStream(IVulnerabilitySourceContext context)
-        {
-            var stream = new SlimMemoryStream();
-
-            using (var textWriter = new StreamWriter(stream, InedoLib.UTF8Encoding, 16, true))
-            using (var jsonWriter = new JsonTextWriter(textWriter))
-            {
-                jsonWriter.WriteStartObject();
-
-                jsonWriter.WritePropertyName("packages");
-                jsonWriter.WriteStartArray();
-
-                foreach (var package in context.Packages)
-                {
-                    jsonWriter.WriteStartObject();
-
-                    jsonWriter.WritePropertyName("pm");
-                    jsonWriter.WriteValue(package.FeedType.ToString().ToLowerInvariant());
-
-                    if (package.Group != null)
-                    {
-                        jsonWriter.WritePropertyName("group");
-                        jsonWriter.WriteValue(package.Group);
-                    }
-
-                    jsonWriter.WritePropertyName("name");
-                    jsonWriter.WriteValue(package.Name);
-
-                    jsonWriter.WriteEndObject();
-                }
-
-                jsonWriter.WriteEndArray();
-
-                jsonWriter.WriteEndObject();
-            }
-
-            stream.Position = 0;
-            return stream;
-        }
-
-        private sealed class ReportStatus
-        {
-            public const string Pending = "pending";
-            public const string Running = "running";
-            public const string Finished = "finished";
-            public const string Error = "error";
-
-            public string id { get; set; }
-            public string status { get; set; }
-            public string statusText { get; set; }
-        }
-
-        private sealed class VorPackage
-        {
-            [JsonProperty(Required = Required.Always)]
-            public long id { get; set; }
-            [JsonProperty(Required = Required.Always)]
-            public string pm
-            {
-                get { return this.FeedType.ToString().ToLowerInvariant(); }
-                set { this.FeedType = (FeedType)Enum.Parse(typeof(FeedType), value, true); }
-            }
-            [JsonProperty(Required = Required.Always)]
-            public string name { get; set; }
-            public VorVulnerability[] vulnerabilities { get; set; }
-
-            [JsonIgnore]
-            public FeedType FeedType { get; set; }
-        }
-
-        private sealed class VorVulnerability
-        {
-            private static readonly LazyRegex VersionRegex = new LazyRegex(@"^(?<1>[<>=]*)(?<2>.+)$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-
-            [JsonProperty(Required = Required.Always)]
-            public long id { get; set; }
-            public string title { get; set; }
-            public string description { get; set; }
-            public string[] versions
-            {
-                set { this.Versions = ParseVersions(value); }
-            }
-            public string[] references { get; set; }
-
-            [JsonIgnore]
-            public VulnerabilityPackageVersionRange Versions { get; set; }
-
-            private static VulnerabilityPackageVersionRange ParseVersions(string[] versions)
-            {
-                if (versions == null || versions.Length == 0 || (versions.Length == 1 && string.IsNullOrWhiteSpace(versions[0])))
-                    return VulnerabilityPackageVersionRange.Any;
-
-                if (versions.Length == 1)
-                    return ParseVersion(versions[0]) ?? VulnerabilityPackageVersionRange.Any;
-
-                return VulnerabilityPackageVersionRange.Multiple(
-                    from v in versions
-                    let p = ParseVersion(v)
-                    where p != null
-                    select p.Value
-                );
-            }
-            private static VulnerabilityPackageVersionRange? ParseVersion(string version)
-            {
-                if (string.IsNullOrWhiteSpace(version))
-                    return null;
-
-                var parts = version.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                if (parts.Length == 1)
-                {
-                    var match = VersionRegex.Match(parts[0]);
-                    if (!match.Success)
-                        return null;
-
-                    var op = match.Groups[1].Value;
-                    if (string.IsNullOrEmpty(op))
-                        return VulnerabilityPackageVersionRange.Single(parts[0]);
-
-                    var ver = match.Groups[2].Value;
-                    switch (op)
-                    {
-                        case "<":
-                            return VulnerabilityPackageVersionRange.Maximum(ver, true);
-                        case "<=":
-                            return VulnerabilityPackageVersionRange.Maximum(ver, false);
-                        case ">":
-                            return VulnerabilityPackageVersionRange.Minimum(ver, true);
-                        case ">=":
-                            return VulnerabilityPackageVersionRange.Maximum(ver, false);
-                        default:
-                            return null;
-                    }
-                }
-                else if (parts.Length == 2)
-                {
-                    var match1 = VersionRegex.Match(parts[0]);
-                    if (!match1.Success)
-                        return null;
-
-                    var op1 = match1.Groups[1].Value;
-
-                    var match2 = VersionRegex.Match(parts[1]);
-                    if (!match2.Success)
-                        return null;
-
-                    var op2 = match2.Groups[1].Value;
-
-                    if (op1 != ">" && op1 != ">=" && op2 != "<" && op2 != "<=")
-                    {
-                        Swap(ref op1, ref op2);
-                        Swap(ref match1, ref match2);
-                    }
-
-                    if ((op1 != ">" && op1 != ">=") || (op2 != "<" && op2 != "<="))
-                        return null;
-
-                    return VulnerabilityPackageVersionRange.Range(match1.Groups[2].Value, op1 == ">", match2.Groups[2].Value, op2 == "<");
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
-
-        private static void Swap<T>(ref T item1, ref T item2)
-        {
-            var temp = item1;
-            item1 = item2;
-            item2 = temp;
-        }
-
-        private sealed class VorVulnerabilityInfo : VulnerabilityInfo
-        {
-            private readonly VorPackage package;
-            private readonly VorVulnerability vulnerability;
-
-            public VorVulnerabilityInfo(VorPackage package, VorVulnerability vulnerability)
-            {
-                this.package = package;
-                this.vulnerability = vulnerability;
-            }
-
-            public override string Id => this.vulnerability.id.ToString();
-            public override FeedType FeedType => this.package.FeedType;
-            public override string PackageName => this.package.name;
-            public override VulnerabilityPackageVersionRange PackageVersions => this.vulnerability.Versions;
-            public override string Title => this.vulnerability.title;
-            public override string Description => this.vulnerability.description;
         }
     }
 }

--- a/VorSecurity/InedoExtension/VulnerabilitySources/Vulnerability.cs
+++ b/VorSecurity/InedoExtension/VulnerabilitySources/Vulnerability.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Inedo.Extensibility.VulnerabilitySources;
+
+namespace Inedo.ProGet.Extensions.VorSecurity.VulnerabilitySources
+{
+    public sealed partial class VorSecurityVulnerabilitySource
+    {
+        private sealed partial class PackageVulnerabilities
+        {
+            [JsonObject]
+            public partial struct Vulnerability
+            {
+                private static readonly DateTimeOffset UnixEpoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+                [JsonProperty("id")]
+                public long ID { get; set; }
+                [JsonProperty("resource")]
+                public string Resource { get; set; }
+                [JsonProperty("title")]
+                public string Title { get; set; }
+                [JsonProperty("description")]
+                public string Description { get; set; }
+                [JsonProperty("versions")]
+                public IReadOnlyList<string> Versions { get; set; }
+                [JsonProperty("references")]
+                public IReadOnlyList<string> References { get; set; }
+                [JsonProperty("cve")]
+                public string CVE { get; set; }
+                [JsonProperty("published")]
+                public long Published { get; set; }
+                [JsonIgnore]
+                public DateTimeOffset PublishedDate => UnixEpoch.AddMilliseconds(this.Published);
+                [JsonProperty("updated")]
+                public long Updated { get; set; }
+                [JsonIgnore]
+                public DateTimeOffset UpdatedDate => UnixEpoch.AddMilliseconds(this.Updated);
+                [JsonProperty("ids")]
+                public IReadOnlyDictionary<string, string> IDs { get; set; }
+
+                internal VulnerabilityInfo GetInfo(PackageVulnerabilities packageVulnerabilities, IEnumerable<PackageId> packages)
+                {
+                    var id = packages.First(packageVulnerabilities.IsMatch);
+                    return new VulnerabilityInfoImpl(this, id);
+                }
+            }
+        }
+    }
+}

--- a/VorSecurity/InedoExtension/VulnerabilitySources/VulnerabilityInfoImpl.cs
+++ b/VorSecurity/InedoExtension/VulnerabilitySources/VulnerabilityInfoImpl.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Inedo.Extensibility.VulnerabilitySources;
+using Inedo.Feeds;
+using System.Text.RegularExpressions;
+
+namespace Inedo.ProGet.Extensions.VorSecurity.VulnerabilitySources
+{
+    public sealed partial class VorSecurityVulnerabilitySource
+    {
+        private sealed partial class PackageVulnerabilities
+        {
+            public partial struct Vulnerability
+            {
+                private sealed class VulnerabilityInfoImpl : VulnerabilityInfo
+                {
+                    internal VulnerabilityInfoImpl(Vulnerability data, PackageId package)
+                    {
+                        this.Id = data.CVE;
+                        this.FeedType = package.Package.FeedType;
+                        this.PackageName = package.Package.Name;
+                        this.PackageVersions = ParseVersions(data.Versions);
+                        this.Title = data.Title;
+                        this.Description = $"{data.Description}\n\n{string.Join("\n", data.IDs.Select(id => $"{id.Key}: {id.Value}"))}\nPublished: {data.PublishedDate}\nUpdated: {data.UpdatedDate}\n\nReferences:\n{string.Join("\n", data.References)}";
+                    }
+
+                    public override string Id { get; }
+                    public override FeedType FeedType { get; }
+                    public override string PackageName { get; }
+                    public override VulnerabilityPackageVersionRange PackageVersions { get; }
+                    public override string Title { get; }
+                    public override string Description { get; }
+
+                    private static readonly LazyRegex VersionRegex = new LazyRegex(@"^(?<1>[<>=]*)(?<2>.+)$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+
+                    private static VulnerabilityPackageVersionRange ParseVersions(IReadOnlyList<string> versions)
+                    {
+                        if (versions == null || versions.Count == 0 || (versions.Count == 1 && string.IsNullOrWhiteSpace(versions[0])))
+                            return VulnerabilityPackageVersionRange.Any;
+
+                        if (versions.Count == 1)
+                            return ParseVersion(versions[0]) ?? VulnerabilityPackageVersionRange.Any;
+
+                        return VulnerabilityPackageVersionRange.Multiple(
+                            from v in versions
+                            let p = ParseVersion(v)
+                            where p != null
+                            select p.Value
+                        );
+                    }
+                    private static VulnerabilityPackageVersionRange? ParseVersion(string version)
+                    {
+                        if (string.IsNullOrWhiteSpace(version))
+                            return null;
+
+                        var parts = version.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length == 1)
+                        {
+                            var match = VersionRegex.Match(parts[0]);
+                            if (!match.Success)
+                                return null;
+
+                            var op = match.Groups[1].Value;
+                            if (string.IsNullOrEmpty(op))
+                                return VulnerabilityPackageVersionRange.Single(parts[0]);
+
+                            var ver = match.Groups[2].Value;
+                            switch (op)
+                            {
+                                case "<":
+                                    return VulnerabilityPackageVersionRange.Maximum(ver, true);
+                                case "<=":
+                                    return VulnerabilityPackageVersionRange.Maximum(ver, false);
+                                case ">":
+                                    return VulnerabilityPackageVersionRange.Minimum(ver, true);
+                                case ">=":
+                                    return VulnerabilityPackageVersionRange.Maximum(ver, false);
+                                default:
+                                    return null;
+                            }
+                        }
+                        else if (parts.Length == 2)
+                        {
+                            var match1 = VersionRegex.Match(parts[0]);
+                            if (!match1.Success)
+                                return null;
+
+                            var op1 = match1.Groups[1].Value;
+
+                            var match2 = VersionRegex.Match(parts[1]);
+                            if (!match2.Success)
+                                return null;
+
+                            var op2 = match2.Groups[1].Value;
+
+                            if (op1 != ">" && op1 != ">=" && op2 != "<" && op2 != "<=")
+                            {
+                                Swap(ref op1, ref op2);
+                                Swap(ref match1, ref match2);
+                            }
+
+                            if ((op1 != ">" && op1 != ">=") || (op2 != "<" && op2 != "<="))
+                                return null;
+
+                            return VulnerabilityPackageVersionRange.Range(match1.Groups[2].Value, op1 == ">", match2.Groups[2].Value, op2 == "<");
+                        }
+                        else
+                        {
+                            return null;
+                        }
+                    }
+                    private static void Swap<T>(ref T item1, ref T item2)
+                    {
+                        var temp = item1;
+                        item1 = item2;
+                        item2 = temp;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Documentation: https://ossindex.sonatype.org/api/package-search

Currently, there does not seem to be support for Maven in the API, and there does not seem to be a mechanism for authentication.